### PR TITLE
only send the role and the content to the OpenAI assistant API

### DIFF
--- a/src/pages/api/chat.js
+++ b/src/pages/api/chat.js
@@ -40,7 +40,10 @@ export default async function handler(req, res) {
             // Find the last user conversation. 
             const lastUserMessage = messages.findLast(message => message.role === 'user');
             const thread = await openai.beta.threads.create({
-                messages: [lastUserMessage]
+                messages: [{
+                    role: lastUserMessage.role,
+                    content: lastUserMessage.content
+                }]
             });
 
             // We use the createAndStream SDK helper to create a run with


### PR DESCRIPTION
only send the role and the content to the OpenAI assistant API
Because the OpenAI assistant API only accept {role, content} as the message input. We will only pass those